### PR TITLE
Expose Total-test files via `add-test` event to jest-reporter

### DIFF
--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -50,6 +50,14 @@ export default class ReporterDispatcher {
     testResult.console = undefined;
   }
 
+  async onTestFileAdd(test: Test): Promise<void> {
+    for (const reporter of this._reporters) {
+      if (reporter.onTestFileAdd) {
+        await reporter.onTestFileAdd(test);
+      }
+    }
+  }
+
   async onTestFileStart(test: Test): Promise<void> {
     for (const reporter of this._reporters) {
       if (reporter.onTestFileStart) {

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -95,6 +95,10 @@ export default class TestScheduler {
 
     const runInBand = shouldRunInBand(tests, timings, this._globalConfig);
 
+    const onTestFileAdd = async (test: TestRunner.Test) => {
+      await this._dispatcher.onTestFileAdd(test);
+    };
+
     const onResult = async (test: TestRunner.Test, testResult: TestResult) => {
       if (watcher.isInterrupted()) {
         return Promise.resolve();
@@ -224,6 +228,7 @@ export default class TestScheduler {
            */
           if (testRunner.__PRIVATE_UNSTABLE_API_supportsEventEmitters__) {
             const unsubscribes = [
+              testRunner.on('test-file-add', ([test]) => onTestFileAdd(test)),
               testRunner.on('test-file-start', ([test]) =>
                 onTestFileStart(test),
               ),

--- a/packages/jest-reporters/src/Status.ts
+++ b/packages/jest-reporters/src/Status.ts
@@ -84,11 +84,13 @@ export default class Status {
   private _estimatedTime: number;
   private _interval?: NodeJS.Timeout;
   private _aggregatedResults?: AggregatedResult;
+  private _testFilesAdded: Array<Test>;
   private _showStatus: boolean;
 
   constructor() {
     this._cache = null;
     this._currentTests = new CurrentTestList();
+    this._testFilesAdded = [];
     this._currentTestCases = [];
     this._done = false;
     this._emitScheduled = false;
@@ -115,6 +117,15 @@ export default class Status {
     this._done = true;
     if (this._interval) clearInterval(this._interval);
     this._emit();
+  }
+
+  addTestFiles(test: Test): void {
+    this._testFilesAdded.push(test);
+    if (!this._showStatus) {
+      this._emit();
+    } else {
+      this._debouncedEmit();
+    }
   }
 
   addTestCaseResult(test: Test, testCaseResult: TestCaseResult): void {
@@ -181,10 +192,10 @@ export default class Status {
       }
     });
 
-    if (this._showStatus && this._aggregatedResults) {
+    if (this._showStatus && this._aggregatedResults && this._testFilesAdded) {
       content +=
         '\n' +
-        getSummary(this._aggregatedResults, {
+        getSummary(this._aggregatedResults, this._testFilesAdded, {
           currentTestCases: this._currentTestCases,
           estimatedTime: this._estimatedTime,
           roundTime: true,

--- a/packages/jest-reporters/src/default_reporter.ts
+++ b/packages/jest-reporters/src/default_reporter.ts
@@ -131,6 +131,10 @@ export default class DefaultReporter extends BaseReporter {
     this._status.runStarted(aggregatedResults, options);
   }
 
+  onTestFileAdd(test: Test): void {
+    this._status.addTestFiles(test);
+  }
+
   onTestStart(test: Test): void {
     this._status.testStarted(test.path, test.context.config);
   }

--- a/packages/jest-reporters/src/summary_reporter.ts
+++ b/packages/jest-reporters/src/summary_reporter.ts
@@ -104,7 +104,7 @@ export default class SummaryReporter extends BaseReporter {
       );
 
       if (numTotalTestSuites) {
-        let message = getSummary(aggregatedResults, {
+        let message = getSummary(aggregatedResults, undefined, {
           estimatedTime: this._estimatedTime,
         });
 

--- a/packages/jest-reporters/src/types.ts
+++ b/packages/jest-reporters/src/types.ts
@@ -54,6 +54,7 @@ export type OnTestFailure = (
 export type OnTestSuccess = (test: Test, result: TestResult) => Promise<any>;
 
 export interface Reporter {
+  readonly onTestFileAdd?: (test: Test) => Promise<void> | void;
   readonly onTestResult?: (
     test: Test,
     testResult: TestResult,

--- a/packages/jest-reporters/src/utils.ts
+++ b/packages/jest-reporters/src/utils.ts
@@ -131,6 +131,7 @@ const getValuesCurrentTestCases = (
 
 export const getSummary = (
   aggregatedResults: AggregatedResult,
+  testFilesAdded?: Array<Test>,
   options?: SummaryOptions,
 ): string => {
   let runTime = (Date.now() - aggregatedResults.startTime) / 1000;
@@ -161,6 +162,7 @@ export const getSummary = (
   const testsPassed = aggregatedResults.numPassedTests;
   const testsPending = aggregatedResults.numPendingTests;
   const testsTodo = aggregatedResults.numTodoTests;
+  const testsTotalAdded = testFilesAdded?.length;
   const testsTotal = aggregatedResults.numTotalTests;
   const width = (options && options.width) || 0;
 
@@ -200,7 +202,10 @@ export const getSummary = (
     (updatedTestsPassed > 0
       ? chalk.bold.green(`${updatedTestsPassed} passed`) + ', '
       : '') +
-    `${updatedTestsTotal} total`;
+    (testsTotalAdded !== updatedTestsTotal
+      ? testsTotalAdded + ' of' + updatedTestsTotal
+      : updatedTestsTotal) +
+    ` total`;
 
   const snapshots =
     chalk.bold('Snapshots:   ') +

--- a/packages/jest-runner/src/types.ts
+++ b/packages/jest-runner/src/types.ts
@@ -43,6 +43,7 @@ export type OnTestSuccess = (
 
 // Typings for `sendMessageToJest` events
 export type TestEvents = {
+  'test-file-add': [Test];
   'test-file-start': [Test];
   'test-file-success': [Test, TestResult];
   'test-file-failure': [Test, SerializableError];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Stacked above https://github.com/facebook/jest/pull/10227
Fixes #31 

## Test plan

- Add `jest-circus` dependency to `jest-reporters`
  - New dependency is introduced, as currently jest-reporter only displays results of tests and test-suites.
  Total-tests added to DescribeBlock are not part of `@jest/test-result`, hence the extra dep
- Use `sendMessageToJest` to emit `DescribeBlock.children` from `add-test` event to `jest-reporter`

